### PR TITLE
Fix UTF8 corruption

### DIFF
--- a/lib/HTML/ExtractContent/Util.pm
+++ b/lib/HTML/ExtractContent/Util.pm
@@ -19,12 +19,8 @@ sub strip {
 
 sub strip_tags {
     my $page = shift;
-
-    my $octets = encode_utf8($page);
     my $hs = HTML::Strip->new;
-    my $stripped = $hs->parse($octets);
-
-    return decode_utf8($stripped);
+    return $hs->parse($page);
 }
 
 sub eliminate_tags {

--- a/lib/HTML/ExtractContent/Util.pm
+++ b/lib/HTML/ExtractContent/Util.pm
@@ -3,9 +3,6 @@ use strict;
 use warnings;
 use utf8;
 
-# core
-use Encode qw/encode_utf8 decode_utf8/;
-
 # cpan
 use Exporter::Lite;
 use HTML::Entities qw(decode_entities);


### PR DESCRIPTION
HTML::Strip had had a bug around handling UTF-8, but it was fixed in v2.00.
https://rt.cpan.org/Public/Bug/Display.html?id=42834
So `encode_utf8` and `decode_utf8` are no more needed.
